### PR TITLE
feat(cordovaserve): support option to use Dotenv plugin

### DIFF
--- a/builders/cordova-serve/schema.d.ts
+++ b/builders/cordova-serve/schema.d.ts
@@ -11,4 +11,5 @@ export interface CordovaServeBuilderSchema {
   cordovaMock?: boolean;
   consolelogs?: boolean;
   consolelogsPort?: number;
+  dotenvConfigPath?: string;
 }

--- a/builders/cordova-serve/schema.json
+++ b/builders/cordova-serve/schema.json
@@ -56,6 +56,10 @@
       "type": "boolean",
       "description": "Bundle empty cordova.js with build",
       "default": false
+    },
+    "dotenvConfigPath": {
+      "type": "string",
+      "description": "Path to Dotenv plugin configuration"
     }
   },
   "additionalProperties": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,12 +6,13 @@
   "packages": {
     "": {
       "name": "@ionic/angular-toolkit",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "dependencies": {
         "@schematics/angular": "^11.2.4",
         "cheerio": "1.0.0-rc.3",
         "colorette": "1.1.0",
         "copy-webpack-plugin": "^6.2.1",
+        "dotenv-webpack": "^7.0.2",
         "tapable": "^2.1.1",
         "tslib": "^2.0.3",
         "ws": "^7.0.1"
@@ -31,6 +32,7 @@
         "@semantic-release/npm": "^5.0.4",
         "@types/cheerio": "0.22.15",
         "@types/copy-webpack-plugin": "^6.0.0",
+        "@types/dotenv-webpack": "^7.0.1",
         "@types/karma": "3.0.5",
         "@types/node": "10.12.30",
         "@types/tapable": "1.0.4",
@@ -2844,6 +2846,15 @@
       "dev": true,
       "dependencies": {
         "@types/webpack": "*"
+      }
+    },
+    "node_modules/@types/dotenv-webpack": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@types/dotenv-webpack/-/dotenv-webpack-7.0.1.tgz",
+      "integrity": "sha512-gpKrNjSWcU2NIJJ/BKFvJt80UJ7NrFxhj0nV0MKrbfsWiFKGgSPzrLJ8/aUgMXSmryEadCDjlPpDC5hGglqJnQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/webpack": "^4"
       }
     },
     "node_modules/@types/express": {
@@ -6951,6 +6962,36 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dotenv-defaults": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv-defaults/-/dotenv-defaults-2.0.1.tgz",
+      "integrity": "sha512-ugFCyBF7ILuwpmznduHPQZBMucHHJ8T4OBManTEVjemxCm2+nqifSuW2lD2SNKdiKSH1E324kZSdJ8M04b4I/A==",
+      "dependencies": {
+        "dotenv": "^8.2.0"
+      }
+    },
+    "node_modules/dotenv-webpack": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/dotenv-webpack/-/dotenv-webpack-7.0.2.tgz",
+      "integrity": "sha512-RY+/5uM/XY4bGtih9f9ic8hlrUDxVcZZBPWlnX/aHhaKxcVVX9SH/5VH7CSmvVo9GL6PKvQOA0X1bc552rnatQ==",
+      "dependencies": {
+        "dotenv-defaults": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "webpack": "^4 || ^5"
       }
     },
     "node_modules/duplexer2": {
@@ -29400,6 +29441,15 @@
         "@types/webpack": "*"
       }
     },
+    "@types/dotenv-webpack": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@types/dotenv-webpack/-/dotenv-webpack-7.0.1.tgz",
+      "integrity": "sha512-gpKrNjSWcU2NIJJ/BKFvJt80UJ7NrFxhj0nV0MKrbfsWiFKGgSPzrLJ8/aUgMXSmryEadCDjlPpDC5hGglqJnQ==",
+      "dev": true,
+      "requires": {
+        "@types/webpack": "^4"
+      }
+    },
     "@types/express": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.11.tgz",
@@ -32727,6 +32777,27 @@
       "dev": true,
       "requires": {
         "is-obj": "^2.0.0"
+      }
+    },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+    },
+    "dotenv-defaults": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv-defaults/-/dotenv-defaults-2.0.1.tgz",
+      "integrity": "sha512-ugFCyBF7ILuwpmznduHPQZBMucHHJ8T4OBManTEVjemxCm2+nqifSuW2lD2SNKdiKSH1E324kZSdJ8M04b4I/A==",
+      "requires": {
+        "dotenv": "^8.2.0"
+      }
+    },
+    "dotenv-webpack": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/dotenv-webpack/-/dotenv-webpack-7.0.2.tgz",
+      "integrity": "sha512-RY+/5uM/XY4bGtih9f9ic8hlrUDxVcZZBPWlnX/aHhaKxcVVX9SH/5VH7CSmvVo9GL6PKvQOA0X1bc552rnatQ==",
+      "requires": {
+        "dotenv-defaults": "^2.0.1"
       }
     },
     "duplexer2": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "cheerio": "1.0.0-rc.3",
     "colorette": "1.1.0",
     "copy-webpack-plugin": "^6.2.1",
+    "dotenv-webpack": "^7.0.2",
     "tapable": "^2.1.1",
     "tslib": "^2.0.3",
     "ws": "^7.0.1"
@@ -55,6 +56,7 @@
     "@semantic-release/npm": "^5.0.4",
     "@types/cheerio": "0.22.15",
     "@types/copy-webpack-plugin": "^6.0.0",
+    "@types/dotenv-webpack": "^7.0.1",
     "@types/karma": "3.0.5",
     "@types/node": "10.12.30",
     "@types/tapable": "1.0.4",


### PR DESCRIPTION
This supports the upgrade in mobile to Angular 11.  If you recall, we patched this when [upgrading to Angular 10](https://github.com/kohofinancial/app/pull/1423) to maintain support for our use of Dotenv with the Cordova serve builder.

As part of upgrading this to the latest version, with support for Angular 11, I also improved the Dotenv plugin support by using the builder options to pass a path to the options in, rather than hardcoding the options into this patch. 